### PR TITLE
Improved doc specifying POST multipart request.

### DIFF
--- a/Overcoat/OVCClient.h
+++ b/Overcoat/OVCClient.h
@@ -72,7 +72,7 @@
                       completion:(void (^)(AFHTTPRequestOperation *operation, id responseObject, NSError *error))block;
 
 /**
- Creates and runs an `AFHTTPRequestOperation` with a `POST` request.
+ Creates and runs an `AFHTTPRequestOperation` with a multipart `POST` request.
  
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.


### PR DESCRIPTION
I've just added the multipart specification to the docs. It's handy when Xcode autocompletes the method.
