### PR TITLE
Adding a Wildcard URL Matcher

### DIFF
--- a/Overcoat/OVCURLMatcher.m
+++ b/Overcoat/OVCURLMatcher.m
@@ -128,7 +128,7 @@ static BOOL OVCTextOnlyContainsDigits(NSString *text) {
                     break;
 
                 case OVCURLMatcherTypeAny:
-                    return n.class;
+                    return n.modelClass;
 
                 case OVCURLMatcherTypeNone:
                     // Do nothing

--- a/Overcoat/OVCURLMatcher.m
+++ b/Overcoat/OVCURLMatcher.m
@@ -28,6 +28,7 @@ typedef NS_ENUM(NSInteger, OVCURLMatcherType) {
     OVCURLMatcherTypeExact  = 0,
     OVCURLMatcherTypeNumber = 1,
     OVCURLMatcherTypeText   = 2,
+    OVCURLMatcherTypeAny    = 3
 };
 
 static BOOL OVCTextOnlyContainsDigits(NSString *text) {
@@ -126,6 +127,9 @@ static BOOL OVCTextOnlyContainsDigits(NSString *text) {
                     node = n;
                     break;
 
+                case OVCURLMatcherTypeAny:
+                    return n.class;
+
                 case OVCURLMatcherTypeNone:
                     // Do nothing
                     break;
@@ -185,7 +189,9 @@ static BOOL OVCTextOnlyContainsDigits(NSString *text) {
 				existingChild.type = OVCURLMatcherTypeNumber;
 			} else if ([token isEqualToString:@"*"]) {
 				existingChild.type = OVCURLMatcherTypeText;
-			} else {
+            } else if ([token isEqualToString:@"**"]) {
+                existingChild.type = OVCURLMatcherTypeAny;
+            } else {
 				existingChild.type = OVCURLMatcherTypeExact;
 			}
             


### PR DESCRIPTION
I am using a Hypermedia API adhering to the [Siren](https://github.com/kevinswiber/siren) specification. Every response should be the same object type. Therefore, I need an any URL wildcard for `modelClassesByResourcePath`. I have decided to use the `**` identifier.