### PR TITLE
Deserialize the response class prior to asking for resultKey path

### DIFF
--- a/Overcoat/OVCResponse.m
+++ b/Overcoat/OVCResponse.m
@@ -44,9 +44,9 @@
     id result = JSONObject;
     
     if ([JSONObject isKindOfClass:[NSDictionary class]]) {
-        NSString *resultKeyPath = [self resultKeyPathForJSONDictionary:JSONObject];
+        response = [MTLJSONAdapter modelOfClass:self fromJSONDictionary:JSONObject error:NULL];
+        NSString *resultKeyPath = [[response class] resultKeyPathForJSONDictionary:JSONObject];
         if (resultKeyPath) {
-            response = [MTLJSONAdapter modelOfClass:self fromJSONDictionary:JSONObject error:NULL];
             result = [(NSDictionary *)JSONObject ovc_objectForKeyPath:resultKeyPath];
         } else {
             response = [[self alloc] init];


### PR DESCRIPTION
This is a fault I came across when trying to use Overcoat in a project. 

The OVCReponse subclass is a mantle model, so we should be able to implement a class-cluster, and specify which specific subclass to deserialize to by overriding `+ (Class)classForParsingJSONDictionary:(NSDictionary *)JSONDictionary`. 

However, this code path calls the class method `resultKeyPathForJSONDictionary:JSONObject` on the (abstract) class, which may not be the correct implementation.

This patch allows the correct subclass to be chosen and instantiated prior to calling `resultKeyPathForJSONDictionary:JSONObject`, which happened to be different each of my class cluster subclasses.
