### PR TITLE
Update PromiseKit to 1.2

### DIFF
--- a/Overcoat.podspec
+++ b/Overcoat.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.subspec 'PromiseKit' do |ss|
     ss.dependency 'Overcoat/Core'
     ss.dependency 'Overcoat/NSURLSession'
-    ss.dependency 'PromiseKit', '0.9.10'
+    ss.dependency 'PromiseKit', '1.2'
     
     ss.public_header_files = 'PromiseKit+Overcoat/*.h'
     ss.source_files = 'PromiseKit+Overcoat'


### PR DESCRIPTION
Update PromiseKit to version 1.2
There is an important fix for using dispatch queues with `.thenOn`, see https://github.com/mxcl/PromiseKit/issues/77
Also a fix for rejected promises: https://github.com/mxcl/PromiseKit/issues/97
