### PR TITLE
Use default responseClass if matcher does not find one

### DIFF
--- a/Overcoat/OVCModelResponseSerializer.m
+++ b/Overcoat/OVCModelResponseSerializer.m
@@ -90,9 +90,11 @@
         
         if (self.URLResponseClassMatcher) {
             responseClass = [self.URLResponseClassMatcher modelClassForURL:HTTPResponse.URL];
-        } else if (self.responseClass) {
+        }
+
+        if (!responseClass) {
             responseClass = self.responseClass;
-        } 
+        }
     } else {
         resultClass = self.errorModelClass;
         responseClass = self.responseClass;


### PR DESCRIPTION
Use self.responseClass as a default if URLResponseClassMatcher cannot find a proper responseClass
