### PR TITLE
Fix Core Data threading issue when saving objects

### DIFF
--- a/Overcoat/OVCModelResponseSerializer.m
+++ b/Overcoat/OVCModelResponseSerializer.m
@@ -131,18 +131,19 @@
 - (void)saveResult:(id)result {
     NSParameterAssert(result);
     
-    NSArray *models = [result isKindOfClass:[NSArray class]] ? result : @[result];
-    for (MTLModel<MTLManagedObjectSerializing> *model in models) {
-        NSError *error = nil;
-        [MTLManagedObjectAdapter managedObjectFromModel:model
-                                   insertingIntoContext:self.managedObjectContext
-                                                  error:&error];
-        NSAssert(error == nil, @"%@ saveResult failed with error: %@", self, error);
-    }
-    
     NSManagedObjectContext *context = self.managedObjectContext;
     
     [context performBlockAndWait:^{
+        NSArray *models = [result isKindOfClass:[NSArray class]] ? result : @[result];
+
+        for (MTLModel<MTLManagedObjectSerializing> *model in models) {
+            NSError *error = nil;
+            [MTLManagedObjectAdapter managedObjectFromModel:model
+                                       insertingIntoContext:context
+                                                      error:&error];
+            NSAssert(error == nil, @"%@ saveResult failed with error: %@", self, error);
+        }
+
         if ([context hasChanges]) {
             NSError *error = nil;
             [context save:&error];


### PR DESCRIPTION
The `-managedObjectFromModel:insertingIntoContext:error:` call will attempt to insert an object into the database and will sometimes fail (especially with large datasets) since it is not running in the same Core Data queue.