### PR TITLE
Overcoat only requires PMKPromise, not all of PMK

### DIFF
--- a/Overcoat.podspec
+++ b/Overcoat.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.subspec 'PromiseKit' do |ss|
     ss.dependency 'Overcoat/Core'
     ss.dependency 'Overcoat/NSURLSession'
-    ss.dependency 'PromiseKit', '~>1.2'
+    ss.dependency 'PromiseKit/Promise', '~>1.2'
     
     ss.public_header_files = 'PromiseKit+Overcoat/*.h'
     ss.source_files = 'PromiseKit+Overcoat'

--- a/PromiseKit+Overcoat/PromiseKit+Overcoat.h
+++ b/PromiseKit+Overcoat/PromiseKit+Overcoat.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <PromiseKit/PromiseKit.h>
+#import <PromiseKit/Promise.h>
 
 #ifndef _PROMISEKIT_OVERCOAT_H
 #define _PROMISEKIT_OVERCOAT_H


### PR DESCRIPTION
Should you ever need more of PromiseKit it’s easy to add more subspecs.