### PR TITLE
Remove OTHER_LDFLAGS build setting to not override cococapods' version

### DIFF
--- a/Overcoat.xcodeproj/project.pbxproj
+++ b/Overcoat.xcodeproj/project.pbxproj
@@ -993,7 +993,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Overcoat/Overcoat-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Overcoat;
 				SKIP_INSTALL = YES;
 			};
@@ -1007,7 +1006,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Overcoat/Overcoat-Prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Overcoat;
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
Remove `OTHER_LDFLAGS` from the main project file to resolve these CocoaPods warnings:

```
[!] The `Overcoat iOS [Debug]` target overrides the `OTHER_LDFLAGS` build setting defined in `Pods/Target Support Files/Pods-Overcoat iOS/Pods-Overcoat iOS.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `Overcoat iOS [Release]` target overrides the `OTHER_LDFLAGS` build setting defined in `Pods/Target Support Files/Pods-Overcoat iOS/Pods-Overcoat iOS.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```