### PR TITLE
Fix URL pattern matching for higher level paths

### DIFF
--- a/Overcoat/Core/OVCURLMatcher.m
+++ b/Overcoat/Core/OVCURLMatcher.m
@@ -98,7 +98,7 @@ static BOOL OVCTextOnlyContainsDigits(NSString *text) {
     for (NSString *u in pathComponents) {
         NSArray *list = node.children;
 
-        if (!list) {
+        if (!list.count) {
             break;
         }
 


### PR DESCRIPTION
The children array on OVCURLMatcher is created in init and therefore always exists. Checking for nil children has no effect, so empty arrays pass the existing check. This causes matching for higher level paths to always fail.

Example) Defining `inventory` in `modelClassesByResourcePath` should match this URL  `inventory/stream/available.json`

```swift
 override class func modelClassesByResourcePath() -> [NSObject: AnyObject] { 
      let modelClasses: [NSObject: AnyObject] = [  
            "inventory": Item.self,  
        ]  
        return modelClasses  
    }  
```

What actually happens is that the enumeration over `pathComponents` will continue and attempt to match each component after inventory. Since there aren't classes defined for each subsequent path, the URL matcher fails altogether.