### PR TITLE
make sure the NSURLSessionDataTask isn't suspended

### DIFF
--- a/sources/Core/OVCHTTPSessionManager.m
+++ b/sources/Core/OVCHTTPSessionManager.m
@@ -157,17 +157,21 @@
         }
         return nil;
     }
+    
+    // `dataTaskWithRequest:completionHandler:` creates a new NSURLSessionDataTask
+    NSURLSessionDataTask *dataTask = [self dataTaskWithRequest:request
+                                             completionHandler:^(NSURLResponse * __unused response, id responseObject, NSError *error) {
+                                                 if (completion) {
+                                                     if (!error) {
+                                                         completion(responseObject, nil);
+                                                     } else {
+                                                         completion(responseObject, error);
+                                                     }
+                                                 }
+                                             }];
 
-    return [self dataTaskWithRequest:request
-                   completionHandler:^(NSURLResponse * __unused response, id responseObject, NSError *error) {
-                       if (completion) {
-                           if (!error) {
-                               completion(responseObject, nil);
-                           } else {
-                               completion(responseObject, error);
-                           }
-                       }
-                   }];
+    [dataTask resume];
+    return dataTask; 
 }
 
 - (NSURLSessionDataTask *)PUT:(NSString *)URLString


### PR DESCRIPTION
This PR fixes `NSURLSessionDataTask` being suspended. `dataTaskWithRequest:completionHandler:` creates a new data task, and it is suspended by default.

@sodastsai please let me know if this makes sense. 