### PR TITLE
Replace inheritance of OVCModelResponseSerializer with composite a json serializer

### DIFF
--- a/sources/Core/OVCModelResponseSerializer.h
+++ b/sources/Core/OVCModelResponseSerializer.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  AFJSONResponseSerializer subclass that validates and transforms a JSON response into a
  `OVCResponse` object.
  */
-@interface OVCModelResponseSerializer : AFJSONResponseSerializer
+@interface OVCModelResponseSerializer : AFHTTPResponseSerializer
 
 /**
  Matches URLs in HTTP responses with model classes.
@@ -51,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
  The model class for server error responses.
  */
 @property (nonatomic, readonly, OVC_NULLABLE) Class errorModelClass;
+
+@property(nonatomic, strong) AFJSONResponseSerializer *jsonSerializer;
 
 /**
  Creates and returns model serializer.

--- a/sources/Core/OVCModelResponseSerializer.m
+++ b/sources/Core/OVCModelResponseSerializer.m
@@ -126,4 +126,19 @@
     return responseObject;
 }
 
+- (NSSet *)acceptableContentTypes
+{
+    return self.jsonSerializer.acceptableContentTypes;
+}
+
+- (NSIndexSet *)acceptableStatusCodes
+{
+    return self.jsonSerializer.acceptableStatusCodes;
+}
+
+- (NSStringEncoding)stringEncoding
+{
+    return self.jsonSerializer.stringEncoding;
+}
+
 @end

--- a/sources/Core/OVCModelResponseSerializer.m
+++ b/sources/Core/OVCModelResponseSerializer.m
@@ -70,7 +70,7 @@
     }
 
     if (self = [super init]) {
-        self.readingOptions = 0;
+        self.jsonSerializer = [AFJSONResponseSerializer serializerWithReadingOptions:0];
 
         self.URLMatcher = URLMatcher;
         self.URLResponseClassMatcher = URLResponseClassMatcher;
@@ -86,7 +86,7 @@
                            data:(NSData *)data
                           error:(NSError *__autoreleasing *)error {
     NSError *serializationError = nil;
-    id OVC__NULLABLE JSONObject = [super responseObjectForResponse:response data:data error:&serializationError];
+    id OVC__NULLABLE JSONObject = [self.jsonSerializer responseObjectForResponse:response data:data error:&serializationError];
     
     if (error) {
         *error = serializationError;


### PR DESCRIPTION
There are reason where you wanna unpack the json different than the AFJSONResponseSerializer, for example when working with http://jwt.io /

When using the jsonSerializer as a copmposite, one can easily exchange it with a different implementation. 