### PR TITLE
Adding error pointer to  [OVCResponse responseWithHTTPResponse:JSONOb…

### DIFF
--- a/sources/Core/OVCModelResponseSerializer.m
+++ b/sources/Core/OVCModelResponseSerializer.m
@@ -117,8 +117,8 @@
 
     OVCResponse *responseObject = [responseClass responseWithHTTPResponse:HTTPResponse
                                                                JSONObject:JSONObject
-                                                              resultClass:resultClass];
-
+                                                              resultClass:resultClass
+                                                                    error:&serializationError];
     if (serializationError && error) {
         *error = [serializationError ovc_errorWithUnderlyingResponse:responseObject];
     }

--- a/sources/Core/OVCResponse.h
+++ b/sources/Core/OVCResponse.h
@@ -22,6 +22,7 @@
 
 #import <Mantle/Mantle.h>
 #import <Overcoat/OVCUtilities.h>
+#import <objc/objc.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -65,9 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
  
  @return A new `OVCResponse` object upon success, or nil if a parsing error occurred.
  */
-+ (OVC_NULLABLE instancetype)responseWithHTTPResponse:(OVC_NULLABLE NSHTTPURLResponse *)HTTPResponse
-                                           JSONObject:(OVC_NULLABLE id)JSONObject
-                                          resultClass:(OVC_NULLABLE Class)resultClass;
++ (OVC__NULLABLE instancetype)responseWithHTTPResponse:(OVC__NULLABLE NSHTTPURLResponse *)HTTPResponse
+                                            JSONObject:(OVC__NULLABLE id)JSONObject
+                                           resultClass:(OVC__NULLABLE Class)resultClass
+                                                 error:(NSError *__autoreleasing *)error;
+
++ (OVC__NULLABLE instancetype)responseWithHTTPResponse:(OVC__NULLABLE NSHTTPURLResponse *)HTTPResponse JSONObject:(OVC__NULLABLE id)JSONObject resultClass:(OVC__NULLABLE Class)resultClass __attribute__((deprecated("Replaced by +responseWithHTTPResponse:JSONObject:resultClass:error:")));
 
 @end
 

--- a/sources/Core/OVCResponse.m
+++ b/sources/Core/OVCResponse.m
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import <objc/objc.h>
 #import "OVCResponse.h"
 #import "OVCUtilities.h"
 #import "NSDictionary+Overcoat.h"
@@ -40,12 +41,14 @@
 
 + (instancetype)responseWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                               JSONObject:(id)JSONObject
-                             resultClass:(Class)resultClass {
+                             resultClass:(Class)resultClass
+                                   error:(NSError *__autoreleasing *)error
+{
     OVCResponse *response = nil;
     id result = JSONObject;
 
     if ([JSONObject isKindOfClass:[NSDictionary class]]) {
-        response = [MTLJSONAdapter modelOfClass:self fromJSONDictionary:JSONObject error:NULL];
+        response = [MTLJSONAdapter modelOfClass:self fromJSONDictionary:JSONObject error:error];
         NSString *resultKeyPath = [[response class] resultKeyPathForJSONDictionary:JSONObject];
         if (resultKeyPath) {
             result = [(NSDictionary *)JSONObject ovc_objectForKeyPath:resultKeyPath];
@@ -101,6 +104,13 @@
         @"resultClass": [NSNull null],
     };
 #endif
+}
+
+#pragma mark - deprecated
+
++ (instancetype)responseWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse JSONObject:(id)JSONObject resultClass:(Class)resultClass
+{
+    return [self responseWithHTTPResponse:HTTPResponse JSONObject:JSONObject resultClass:resultClass error:NULL];
 }
 
 @end

--- a/tests/OVCResponseTests.m
+++ b/tests/OVCResponseTests.m
@@ -38,7 +38,8 @@
 - (void)testNilJSONDictionary {
     OVCResponse *response = [OVCResponse responseWithHTTPResponse:self.HTTPResponse
                                                        JSONObject:nil
-                                                      resultClass:[OVCTestModel class]];
+                                                      resultClass:[OVCTestModel class]
+                                                            error:NULL];
     
     XCTAssertEqualObjects(self.HTTPResponse, response.HTTPResponse, @"should initialize HTTP response");
     XCTAssertNil(response.result, @"result should be nil");
@@ -51,8 +52,9 @@
     };
     
     OVCResponse *response = [OVCResponse responseWithHTTPResponse:self.HTTPResponse
-                                                   JSONObject:JSONObject
-                                                      resultClass:nil];
+                                                       JSONObject:JSONObject
+                                                      resultClass:nil
+                                                            error:NULL];
     
     XCTAssertEqualObjects(self.HTTPResponse, response.HTTPResponse, @"should initialize HTTP response");
     XCTAssertEqualObjects(JSONObject, response.result, @"should initialize result to JSON object");
@@ -66,7 +68,8 @@
     
     OVCResponse *response = [OVCResponse responseWithHTTPResponse:self.HTTPResponse
                                                        JSONObject:JSONObject
-                                                      resultClass:[OVCTestModel class]];
+                                                      resultClass:[OVCTestModel class]
+                                                            error:NULL];
     
     XCTAssertEqualObjects(self.HTTPResponse, response.HTTPResponse, @"should initialize HTTP response");
     
@@ -91,7 +94,8 @@
     
     OVCResponse *response = [OVCResponse responseWithHTTPResponse:self.HTTPResponse
                                                        JSONObject:JSONObject
-                                                      resultClass:[OVCTestModel class]];
+                                                      resultClass:[OVCTestModel class]
+                                                            error:NULL];
     
     XCTAssertEqualObjects(self.HTTPResponse, response.HTTPResponse, @"should initialize HTTP response");
     
@@ -124,9 +128,10 @@
         ]
     };
     
-    OVCTestResponse *response = [OVCTestResponse responseWithHTTPResponse:self.HTTPResponse
+    OVCTestResponse *response = [OVCTestResponse responseWithHTTPResponse:self.HTTPResponse 
                                                                JSONObject:JSONObject
-                                                              resultClass:[OVCTestModel class]];
+                                                              resultClass:[OVCTestModel class]
+                                                                    error:NULL];
     
     XCTAssertEqualObjects(self.HTTPResponse, response.HTTPResponse, @"should initialize HTTP response");
     


### PR DESCRIPTION
Adding error pointer to  [OVCResponse responseWithHTTPResponse:JSONObject:resultClass]
If [MTLJSONAdapter modelOfClass:self fromJSONDictionary:JSONObject error:error]; isn't successful, the error should be set. 