### PR TITLE
Use the error pointer for [NSValueTransformer transformedValue:]

### DIFF
--- a/sources/Core/OVCResponse.m
+++ b/sources/Core/OVCResponse.m
@@ -74,14 +74,23 @@
             } else if ([result isKindOfClass:[NSArray class]]) {
                 valueTransformer = [MTLJSONAdapter arrayTransformerWithModelClass:resultClass];
             }
+
+            if ([valueTransformer conformsToProtocol:@protocol(MTLTransformerErrorHandling)]) {
+                result = [(NSValueTransformer <MTLTransformerErrorHandling> *) valueTransformer transformedValue:result
+                                                                                                         success:NULL
+                                                                                                           error:error];
+            } else {
+                result = [valueTransformer transformedValue:result];
+            }
 #else
             if ([result isKindOfClass:[NSDictionary class]]) {
                 valueTransformer = [NSValueTransformer mtl_JSONDictionaryTransformerWithModelClass:resultClass];
             } else if ([result isKindOfClass:[NSArray class]]) {
                 valueTransformer = [NSValueTransformer mtl_JSONArrayTransformerWithModelClass:resultClass];
             }
-#endif
+
             result = [valueTransformer transformedValue:result];
+#endif
         }
 
         response.result = result;


### PR DESCRIPTION
Mantle 2 has the new protocol MTLTransformerErrorHandling. Let's use it if the value transformer supports it.