### PR TITLE
Headers must be marked `public`, not project` for OC-RAC iOS framework

### DIFF
--- a/Overcoat.xcodeproj/project.pbxproj
+++ b/Overcoat.xcodeproj/project.pbxproj
@@ -46,9 +46,9 @@
 		FE1041331C8AAFA300C3A1FD /* OMGHTTPURLRQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6031C8AAC7F003BB99E /* OMGHTTPURLRQ.framework */; };
 		FE1041341C8AAFA300C3A1FD /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6041C8AAC7F003BB99E /* PromiseKit.framework */; };
 		FE1041441C8AAFA700C3A1FD /* Overcoat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF5C61C8AA9B0003BB99E /* Overcoat.framework */; };
-		FE1041501C8AAFCE00C3A1FD /* OVCHTTPSessionManager+ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B61C899E5C003BB99E /* OVCHTTPSessionManager+ReactiveCocoa.h */; };
+		FE1041501C8AAFCE00C3A1FD /* OVCHTTPSessionManager+ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B61C899E5C003BB99E /* OVCHTTPSessionManager+ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE1041511C8AAFCE00C3A1FD /* OVCHTTPSessionManager+ReactiveCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEEF5B71C899E5C003BB99E /* OVCHTTPSessionManager+ReactiveCocoa.m */; };
-		FE1041521C8AAFCE00C3A1FD /* OvercoatReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B81C899E5C003BB99E /* OvercoatReactiveCocoa.h */; };
+		FE1041521C8AAFCE00C3A1FD /* OvercoatReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B81C899E5C003BB99E /* OvercoatReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE1041531C8AAFCF00C3A1FD /* OVCHTTPSessionManager+ReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B61C899E5C003BB99E /* OVCHTTPSessionManager+ReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE1041541C8AAFCF00C3A1FD /* OVCHTTPSessionManager+ReactiveCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEEF5B71C899E5C003BB99E /* OVCHTTPSessionManager+ReactiveCocoa.m */; };
 		FE1041551C8AAFCF00C3A1FD /* OvercoatReactiveCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B81C899E5C003BB99E /* OvercoatReactiveCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };


### PR DESCRIPTION
Looks like this was just an oversight, as they're marked public in all the other frameworks -- just not for Overcoat-ReactiveCocoa-iOS