### PR TITLE
Set up the exact version of PromiseKit library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ profile
 Pods
 # Carthage
 Carthage
+DerivedData

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 install:
   - gem list cocoapods | grep ^cocoapods | awk '{print $1'} | xargs gem uninstall --all

--- a/Cartfile
+++ b/Cartfile
@@ -2,5 +2,5 @@ github "AFNetworking/AFNetworking" ~> 3.0
 github "Mantle/Mantle" ~> 2.0
 
 github "Mantle/MTLManagedObjectAdapter" "master"
-github "mxcl/PromiseKit" >= 2.0
+github "mxcl/PromiseKit" == 3.4.4
 github "ReactiveCocoa/ReactiveCocoa" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,6 @@
 github "AFNetworking/AFNetworking" "3.1.0"
 github "Mantle/Mantle" "2.0.7"
-github "mxcl/OMGHTTPURLRQ" "3.1.1"
+github "mxcl/PromiseKit" "3.4.4"
 github "antitypical/Result" "2.0.0"
 github "Mantle/MTLManagedObjectAdapter" "9629d7c1f6b4710eb2dbcfb6f401e20d7fe8871b"
-github "mxcl/PromiseKit" "3.1.1"
 github "ReactiveCocoa/ReactiveCocoa" "v4.1.0"

--- a/Overcoat.xcodeproj/project.pbxproj
+++ b/Overcoat.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		FE0A7A091C8AADCB003DAA0C /* MTLManagedObjectAdapter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6021C8AAC7F003BB99E /* MTLManagedObjectAdapter.framework */; };
 		FE0A7A191C8AAE57003DAA0C /* Overcoat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF5C61C8AA9B0003BB99E /* Overcoat.framework */; };
 		FE0A7A1A1C8AAE60003DAA0C /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6091C8AAC94003BB99E /* PromiseKit.framework */; };
-		FE0A7A1B1C8AAE9B003DAA0C /* OMGHTTPURLRQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6081C8AAC94003BB99E /* OMGHTTPURLRQ.framework */; };
 		FE0A7A1C1C8AAEA9003DAA0C /* OVCHTTPSessionManager+PromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B21C899E5C003BB99E /* OVCHTTPSessionManager+PromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE0A7A1D1C8AAEA9003DAA0C /* OVCHTTPSessionManager+PromiseKit.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEEF5B31C899E5C003BB99E /* OVCHTTPSessionManager+PromiseKit.m */; };
 		FE0A7A1E1C8AAEA9003DAA0C /* OvercoatPromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B41C899E5C003BB99E /* OvercoatPromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -42,7 +41,6 @@
 		FE0A7A2D1C8AAEDB003DAA0C /* OVCHTTPSessionManager+PromiseKit.m in Sources */ = {isa = PBXBuildFile; fileRef = FEEEF5B31C899E5C003BB99E /* OVCHTTPSessionManager+PromiseKit.m */; };
 		FE0A7A2E1C8AAEDB003DAA0C /* OvercoatPromiseKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FEEEF5B41C899E5C003BB99E /* OvercoatPromiseKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FE0A7A311C8AAEEE003DAA0C /* Overcoat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF5E71C8AAAA8003BB99E /* Overcoat.framework */; };
-		FE0A7A321C8AAEF2003DAA0C /* OMGHTTPURLRQ.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6031C8AAC7F003BB99E /* OMGHTTPURLRQ.framework */; };
 		FE0A7A331C8AAEF2003DAA0C /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF6041C8AAC7F003BB99E /* PromiseKit.framework */; };
 		FE1041321C8AAFA300C3A1FD /* Overcoat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF5E71C8AAAA8003BB99E /* Overcoat.framework */; };
 		FE1041441C8AAFA700C3A1FD /* Overcoat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FEEEF5C61C8AA9B0003BB99E /* Overcoat.framework */; };
@@ -318,7 +316,6 @@
 			files = (
 				FE0A7A191C8AAE57003DAA0C /* Overcoat.framework in Frameworks */,
 				FE0A7A1A1C8AAE60003DAA0C /* PromiseKit.framework in Frameworks */,
-				FE0A7A1B1C8AAE9B003DAA0C /* OMGHTTPURLRQ.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,7 +324,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				FE0A7A311C8AAEEE003DAA0C /* Overcoat.framework in Frameworks */,
-				FE0A7A321C8AAEF2003DAA0C /* OMGHTTPURLRQ.framework in Frameworks */,
 				FE0A7A331C8AAEF2003DAA0C /* PromiseKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Right now inside Carthage file PromiseKit library version is specified as >= 2.0. Therefore currently Carthage installs PromiseKit v4.0.0 by default as it's latest PromiseKit version. But according to PromiseKit documentation all library versions starting from 3.5.0 are only supported by XCode 8.0 that is in beta testing right now. Also PromiseKit developers suggest to include `github "mxcl/PromiseKit" ~> 3.4` line to your Carthage file to install the library. However, following such rule Carthage installs PromiseKit v3.5.0, that is also supported only by XCode 8.0. This can be explained by the fact that Carthage works according to [Semantic Versioning](http://semver.org/). So the only reasonable solution I could imagine is to specify the exact latest version of the library that supports XCode 7. 
Please, review and merge this PR when you have a chance, because right now Overcoat can't be used if you don't have XCode 8 installed.
Also very open for any other solutions for this issue. 