### PR TITLE
Progress

### DIFF
--- a/sources/Core/OVCHTTPSessionManager.h
+++ b/sources/Core/OVCHTTPSessionManager.h
@@ -81,23 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
- @param completion A block to be executed when the request finishes.
- */
-- (OVC_NULLABLE NSURLSessionDataTask *)GET:(NSString *)URLString
-                                parameters:(OVC_NULLABLE id)parameters
-                                completion:(OVC_NULLABLE void(^)
-                                            (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
-                                             NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
-
-/**
- Creates and runs an `NSURLSessionDataTask` with a `GET` request.
-
- If the request completes successfully, the `response` parameter of the completion block contains a
- `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
- contains information about the failure.
-
- @param URLString The URL string used to create the request URL.
- @param parameters The parameters to be encoded according to the client request serializer.
  @param downloadProgress A block object to be executed when the download progress is updated. Note this block is called on the session queue, not the main queue.
  @param completion A block to be executed when the request finishes.
  */
@@ -126,23 +109,6 @@ NS_ASSUME_NONNULL_BEGIN
                                               NSError * OVC__NULLABLE error))completion;
 
 /**
- Creates and runs an `NSURLSessionDataTask` with a `POST` request.
-
- If the request completes successfully, the `response` parameter of the completion block contains a
- `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
- contains information about the failure.
-
- @param URLString The URL string used to create the request URL.
- @param parameters The parameters to be encoded according to the client request serializer.
- @param completion A block to be executed when the request finishes.
- */
-- (OVC_NULLABLE NSURLSessionDataTask *)POST:(NSString *)URLString
-                                 parameters:(OVC_NULLABLE id)parameters
-                                 completion:(OVC_NULLABLE void(^)
-                                             (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
-                                              NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
-
-/**
  Creates and runs an `NSURLSessionDataTask` with a multipart `POST` request.
 
  If the request completes successfully, the `response` parameter of the completion block contains a
@@ -151,16 +117,15 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
- @param block A block that takes a single argument and appends data to the HTTP body. The block
- argument is an object adopting the `AFMultipartFormData` protocol.
+ @param uploadProgress A block object to be executed when the upload progress is updated. Note this block is called on the session queue, not the main queue.
  @param completion A block to be executed when the request finishes.
  */
 - (OVC_NULLABLE NSURLSessionDataTask *)POST:(NSString *)URLString
                                  parameters:(OVC_NULLABLE id)parameters
-                  constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData))block
+                                   progress:(OVC_NULLABLE void(^)(NSProgress *uploadProgress))uploadProgress
                                  completion:(OVC_NULLABLE void(^)
                                              (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
-                                              NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
+                                              NSError * OVC__NULLABLE error))completion;
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a multipart `POST` request.
@@ -239,10 +204,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Deprecated Methods
 
-@interface OVCHTTPSessionManager (Deprecated)
+@interface OVCHTTPSessionManager OVCGenerics(ResponseType: OVCResponse *) (Deprecated)
 
 + (Class)responseClass OVC_DEPRECATED("Use `responseClassesByResourcePath` instead.");
 + (OVC_NULLABLE Class)errorModelClass OVC_DEPRECATED("Use `errorModelClassesByResourcePath` instead.");
+
+- (OVC_NULLABLE NSURLSessionDataTask *)GET:(NSString *)URLString
+                                parameters:(OVC_NULLABLE id)parameters
+                                completion:(OVC_NULLABLE void(^)
+                                            (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
+                                             NSError * OVC__NULLABLE error))completion OVC_DEPRECATED("Use `GET:parameters:progress:completion:` instead.");
+- (OVC_NULLABLE NSURLSessionDataTask *)POST:(NSString *)URLString
+                                 parameters:(OVC_NULLABLE id)parameters
+                                 completion:(OVC_NULLABLE void(^)
+                                             (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
+                                              NSError * OVC__NULLABLE error))completion OVC_DEPRECATED("Use `POST:parameters:progress:completion:` instead.");
+- (OVC_NULLABLE NSURLSessionDataTask *)POST:(NSString *)URLString
+                                 parameters:(OVC_NULLABLE id)parameters
+                  constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData))block
+                                 completion:(OVC_NULLABLE void(^)
+                                             (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
+                                              NSError * OVC__NULLABLE error))completion OVC_DEPRECATED("Use `POST:parameters:constructingBodyWithBlock:progress:completion:` instead.");
 
 @end
 

--- a/sources/Core/OVCHTTPSessionManager.h
+++ b/sources/Core/OVCHTTPSessionManager.h
@@ -74,11 +74,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `GET` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.
@@ -87,15 +87,34 @@ NS_ASSUME_NONNULL_BEGIN
                                 parameters:(OVC_NULLABLE id)parameters
                                 completion:(OVC_NULLABLE void(^)
                                             (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
-                                             NSError * OVC__NULLABLE error))completion;
+                                             NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `GET` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded according to the client request serializer.
+ @param downloadProgress A block object to be executed when the download progress is updated. Note this block is called on the session queue, not the main queue.
+ @param completion A block to be executed when the request finishes.
+ */
+- (OVC_NULLABLE NSURLSessionDataTask *)GET:(NSString *)URLString
+                                parameters:(OVC_NULLABLE id)parameters
+                                  progress:(OVC_NULLABLE void(^)(NSProgress *downloadProgress))downloadProgress
+                                completion:(OVC_NULLABLE void(^)
+                                            (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
+                                             NSError * OVC__NULLABLE error))completion;
+
+/**
+ Creates and runs an `NSURLSessionDataTask` with a `HEAD` request.
+
+ If the request completes successfully, the `response` parameter of the completion block contains a
+ `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
+ contains information about the failure.
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.
@@ -108,11 +127,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `POST` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.
@@ -121,15 +140,15 @@ NS_ASSUME_NONNULL_BEGIN
                                  parameters:(OVC_NULLABLE id)parameters
                                  completion:(OVC_NULLABLE void(^)
                                              (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
-                                              NSError * OVC__NULLABLE error))completion;
+                                              NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a multipart `POST` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param block A block that takes a single argument and appends data to the HTTP body. The block
@@ -141,15 +160,37 @@ NS_ASSUME_NONNULL_BEGIN
                   constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData))block
                                  completion:(OVC_NULLABLE void(^)
                                              (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
+                                              NSError * OVC__NULLABLE error))completion DEPRECATED_ATTRIBUTE;
+
+/**
+ Creates and runs an `NSURLSessionDataTask` with a multipart `POST` request.
+
+ If the request completes successfully, the `response` parameter of the completion block contains a
+ `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
+ contains information about the failure.
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded according to the client request serializer.
+ @param block A block that takes a single argument and appends data to the HTTP body. The block
+ argument is an object adopting the `AFMultipartFormData` protocol.
+ @param uploadProgress A block object to be executed when the upload progress is updated. Note this block is called on the session queue, not the main queue.
+ @param completion A block to be executed when the request finishes.
+ */
+- (OVC_NULLABLE NSURLSessionDataTask *)POST:(NSString *)URLString
+                                 parameters:(OVC_NULLABLE id)parameters
+                  constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData))block
+                                   progress:(OVC_NULLABLE void(^)(NSProgress *uploadProgress))uploadProgress
+                                 completion:(OVC_NULLABLE void(^)
+                                             (OVCGenericType(ResponseType, OVCResponse *) OVC__NULLABLE response,
                                               NSError * OVC__NULLABLE error))completion;
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `PUT` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.
@@ -162,11 +203,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `PATCH` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.
@@ -179,11 +220,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates and runs an `NSURLSessionDataTask` with a `DELETE` request.
- 
+
  If the request completes successfully, the `response` parameter of the completion block contains a
  `OVCResponse` object, and the `error` parameter is `nil`. If the request fails, the error parameter
  contains information about the failure.
- 
+
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
  @param completion A block to be executed when the request finishes.

--- a/sources/Core/OVCHTTPSessionManager.m
+++ b/sources/Core/OVCHTTPSessionManager.m
@@ -181,6 +181,20 @@
 
 - (NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(id)parameters
+                      progress:(void (^)(NSProgress *uploadProgress))uploadProgress
+                    completion:(void (^)(OVCResponse *, NSError *))completion {
+    NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"POST"
+                                                     URLString:URLString
+                                                    parameters:parameters
+                                                uploadProgress:uploadProgress
+                                              downloadProgress:nil
+                                                    completion:completion];
+    [task resume];
+    return task;
+}
+
+- (NSURLSessionDataTask *)POST:(NSString *)URLString
+                    parameters:(id)parameters
      constructingBodyWithBlock:(void (^)(id<AFMultipartFormData> formData))block
                       progress:(void (^)(NSProgress *uploadProgress))uploadProgress
                     completion:(void (^)(OVCResponse *, NSError *))completion {

--- a/sources/Core/OVCHTTPSessionManager.m
+++ b/sources/Core/OVCHTTPSessionManager.m
@@ -78,6 +78,8 @@
 - (NSURLSessionDataTask *)_dataTaskWithHTTPMethod:(NSString *)method
                                         URLString:(NSString *)URLString
                                        parameters:(id)parameters
+                                   uploadProgress:(void (^)(NSProgress *uploadProgress))uploadProgress
+                                 downloadProgress:(void (^)(NSProgress *downloadProgress))downloadProgress
                                        completion:(void (^)(OVCResponse *, NSError *))completion {
     // The implementation is copied from AFNetworking ... (Since we want to pass `responseObject`)
     // (Superclass implemenration doesn't return response object.)
@@ -101,6 +103,8 @@
     }
 
     return [self dataTaskWithRequest:request
+                      uploadProgress:uploadProgress
+                    downloadProgress:downloadProgress
                    completionHandler:^(NSURLResponse * __unused response, id responseObject, NSError *error) {
                        if (completion) {
                            if (!error) {
@@ -116,9 +120,22 @@
 - (NSURLSessionDataTask *)GET:(NSString *)URLString
                    parameters:(id)parameters
                    completion:(void (^)(OVCResponse *, NSError *))completion {
+    NSURLSessionDataTask *task = [self GET:URLString
+                                parameters:parameters
+                                  progress:nil
+                                completion:completion];
+    return task;
+}
+
+- (NSURLSessionDataTask *)GET:(NSString *)URLString
+                   parameters:(id)parameters
+                     progress:(void (^)(NSProgress *downloadProgress))downloadProgress
+                   completion:(void (^)(OVCResponse *, NSError *))completion {
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"GET"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:downloadProgress
                                                     completion:completion];
     [task resume];
     return task;
@@ -130,6 +147,8 @@
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"HEAD"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:nil
                                                     completion:completion];
     [task resume];
     return task;
@@ -141,6 +160,8 @@
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"POST"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:nil
                                                     completion:completion];
     [task resume];
     return task;
@@ -149,6 +170,19 @@
 - (NSURLSessionDataTask *)POST:(NSString *)URLString
                     parameters:(id)parameters
      constructingBodyWithBlock:(void (^)(id<AFMultipartFormData>))block
+                    completion:(void (^)(OVCResponse *, NSError *))completion {
+        NSURLSessionDataTask *task = [self POST:URLString
+                                     parameters:parameters
+                      constructingBodyWithBlock:block
+                                       progress:nil
+                                     completion:completion];
+    return task;
+}
+
+- (NSURLSessionDataTask *)POST:(NSString *)URLString
+                    parameters:(id)parameters
+     constructingBodyWithBlock:(void (^)(id<AFMultipartFormData> formData))block
+                      progress:(void (^)(NSProgress *uploadProgress))uploadProgress
                     completion:(void (^)(OVCResponse *, NSError *))completion {
     // The implementation is copied from AFNetworking ... (Since we want to pass `responseObject`)
     // (Superclass implemenration doesn't return response object.)
@@ -171,23 +205,24 @@
         }
         return nil;
     }
-    
+
     // `dataTaskWithRequest:completionHandler:` creates a new NSURLSessionDataTask
-    NSURLSessionDataTask *dataTask = [self dataTaskWithRequest:request
-                                             completionHandler:^(NSURLResponse * __unused response,
-                                                                 id responseObject,
-                                                                 NSError *error) {
-                                                 if (completion) {
-                                                     if (!error) {
-                                                         completion(responseObject, nil);
-                                                     } else {
-                                                         completion(responseObject, error);
-                                                     }
-                                                 }
-                                             }];
+    NSURLSessionDataTask *dataTask = [self uploadTaskWithStreamedRequest:request
+                                                                progress:uploadProgress
+                                                       completionHandler:^(NSURLResponse * __unused response,
+                                                                           id responseObject,
+                                                                           NSError *error) {
+                                                           if (completion) {
+                                                               if (!error) {
+                                                                   completion(responseObject, nil);
+                                                               } else {
+                                                                   completion(responseObject, error);
+                                                               }
+                                                           }
+                                                       }];
 
     [dataTask resume];
-    return dataTask; 
+    return dataTask;
 }
 
 - (NSURLSessionDataTask *)PUT:(NSString *)URLString
@@ -196,6 +231,8 @@
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"PUT"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:nil
                                                     completion:completion];
     [task resume];
     return task;
@@ -207,6 +244,8 @@
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"PATCH"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:nil
                                                     completion:completion];
     [task resume];
     return task;
@@ -218,6 +257,8 @@
     NSURLSessionDataTask *task = [self _dataTaskWithHTTPMethod:@"DELETE"
                                                      URLString:URLString
                                                     parameters:parameters
+                                                uploadProgress:nil
+                                              downloadProgress:nil
                                                     completion:completion];
     [task resume];
     return task;

--- a/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.h
+++ b/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.h
@@ -24,6 +24,7 @@
 #import <Overcoat/OVCUtilities.h>
 
 @class RACSignal;
+@protocol RACSubscriber;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,10 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
+ @param downloadProgress Subscribes `downloadProgress` to `next` events with `NSProgress` object,
+ to be sent on each downloading object update and completes then, send error on downloading error.
 
  @return A cold signal which sends a `OVCResponse` on next event and completes, or error otherwise
  */
-- (RACSignal *)rac_GET:(NSString *)URLString parameters:(OVC_NULLABLE id)parameters;
+- (RACSignal *)rac_GET:(NSString *)URLString
+            parameters:(OVC_NULLABLE id)parameters
+              progress:(OVC_NULLABLE id<RACSubscriber>)downloadProgress;
 
 /**
  Enqueues a `HEAD` request.
@@ -54,10 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param URLString The URL string used to create the request URL.
  @param parameters The parameters to be encoded according to the client request serializer.
+ @param uploadProgress Subscribes `uploadProgress` to `next` events with `NSProgress` object,
+ to be sent on each uploading object update and completes then, send error on uploading error.
 
  @return A cold signal which sends a `OVCResponse` on next event and completes, or error otherwise
  */
-- (RACSignal *)rac_POST:(NSString *)URLString parameters:(OVC_NULLABLE id)parameters;
+- (RACSignal *)rac_POST:(NSString *)URLString
+             parameters:(OVC_NULLABLE id)parameters
+               progress:(OVC_NULLABLE id<RACSubscriber>)uploadProgress;
 
 /**
  Enqueues a multipart `POST` request.
@@ -66,12 +75,15 @@ NS_ASSUME_NONNULL_BEGIN
  @param parameters The parameters to be encoded according to the client request serializer.
  @param block A block that takes a single argument and appends data to the HTTP body. The block
  argument is an object adopting the `AFMultipartFormData` protocol.
+ @param uploadProgress Subscribes `uploadProgress` to `next` events with `NSProgress` object,
+ to be sent on each uploading object update and completes then, send error on uploading error.
 
  @return A cold signal which sends a `OVCResponse` on next event and completes, or error otherwise
  */
 - (RACSignal *)rac_POST:(NSString *)URLString
              parameters:(OVC_NULLABLE id)parameters
-constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData))block;
+constructingBodyWithBlock:(void(^)(id<AFMultipartFormData> formData))block
+               progress:(OVC_NULLABLE id<RACSubscriber>)uploadProgress;
 
 /**
  Enqueues a `PUT` request.
@@ -102,6 +114,48 @@ constructingBodyWithBlock:(OVC_NULLABLE void(^)(id<AFMultipartFormData> formData
  @return A cold signal which sends a `OVCResponse` on next event and completes, or error otherwise
  */
 - (RACSignal *)rac_DELETE:(NSString *)URLString parameters:(OVC_NULLABLE id)parameters;
+
+@end
+
+#pragma mark - Deprecated Methods
+
+@interface OVCHTTPSessionManager (ReactiveCocoa_Deprecated)
+
+/**
+ Enqueues a `GET` request.
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded according to the client request serializer.
+
+ @return A cold signal which sends a `NSProgress` object on each downloading object update
+ and `OVCResponse` when downloading complete on next event and completes, or error otherwise
+ */
+- (RACSignal *)rac_GET:(NSString *)URLString parameters:(OVC_NULLABLE id)parameters OVC_DEPRECATED("Use `rac_GET:parameters:progress:` instead.");
+
+/**
+ Enqueues a `POST` request.
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded according to the client request serializer.
+
+ @return A cold signal which sends a `NSProgress` object on each uploading object update
+ and `OVCResponse` when uploading complete on next event and completes, or error otherwise
+ */
+- (RACSignal *)rac_POST:(NSString *)URLString parameters:(OVC_NULLABLE id)parameters OVC_DEPRECATED("Use `rac_POST:parameters:progress:` instead.");
+
+/**
+ Enqueues a multipart `POST` request.
+
+ @param URLString The URL string used to create the request URL.
+ @param parameters The parameters to be encoded according to the client request serializer.
+ @param block A block that takes a single argument and appends data to the HTTP body. The block
+ argument is an object adopting the `AFMultipartFormData` protocol.
+
+ @return A cold signal which sends a `OVCResponse` on next event and completes, or error otherwise
+ */
+- (RACSignal *)rac_POST:(NSString *)URLString
+             parameters:(OVC_NULLABLE id)parameters
+constructingBodyWithBlock:(void(^)(id<AFMultipartFormData> formData))block OVC_DEPRECATED("Use `rac_POST:parameters:constructingBodyWithBlock:progress:` instead.");
 
 @end
 

--- a/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.m
+++ b/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.m
@@ -31,6 +31,7 @@
     return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         __block NSURLSessionDataTask *task = [self GET:URLString
                                             parameters:parameters
+                                              progress:nil
                                             completion:^(id response, NSError *error) {
                                                 if (!error) {
                                                     [subscriber sendNext:response];
@@ -46,8 +47,7 @@
     }] setNameWithFormat:@"%@ -rac_GET: %@, parameters: %@", self.class, URLString, parameters];
 }
 
-- (RACSignal *)rac_HEAD:(NSString *)URLString parameters:(NSDictionary *)parameters
-{
+- (RACSignal *)rac_HEAD:(NSString *)URLString parameters:(NSDictionary *)parameters {
     return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         __block NSURLSessionDataTask *task = [self HEAD:URLString
                                              parameters:parameters
@@ -70,6 +70,7 @@
     return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
         __block NSURLSessionDataTask *task = [self POST:URLString
                                              parameters:parameters
+                                               progress:nil
                                              completion:^(id response, NSError *error) {
                                                  if (!error) {
                                                      [subscriber sendNext:response];
@@ -92,6 +93,7 @@ constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block {
         __block NSURLSessionDataTask *task = [self POST:URLString
                                              parameters:parameters
                               constructingBodyWithBlock:block
+                                               progress:nil
                                              completion:^(id response, NSError *error) {
                                                  if (!error) {
                                                      [subscriber sendNext:response];
@@ -163,6 +165,92 @@ constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block {
             [task cancel];
         }];
     }] setNameWithFormat:@"%@ -rac_DELETE: %@, parameters: %@", self.class, URLString, parameters];
+}
+
+#pragma mark -
+
+- (RACSignal *)rac_GET:(NSString *)URLString
+            parameters:(NSDictionary *)parameters
+              progress:(id<RACSubscriber>)progress {
+    return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+        __block NSURLSessionDataTask *task = [self GET:URLString
+                                            parameters:parameters
+                                              progress:^(NSProgress *downloadProgress) {
+                                                  [progress sendNext:downloadProgress];
+                                              }
+                                            completion:^(id response, NSError *error) {
+                                                if (!error) {
+                                                    [progress sendCompleted];
+                                                    [subscriber sendNext:response];
+                                                    [subscriber sendCompleted];
+                                                } else {
+                                                    [progress sendError:error];
+                                                    [subscriber sendError:error];
+                                                }
+                                            }];
+
+        return [RACDisposable disposableWithBlock:^{
+            [task cancel];
+        }];
+    }] setNameWithFormat:@"%@ -rac_GET: %@, parameters: %@, progress: %@",
+            self.class, URLString, parameters, progress];
+}
+
+
+- (RACSignal *)rac_POST:(NSString *)URLString
+             parameters:(NSDictionary *)parameters
+               progress:(id<RACSubscriber>)progress {
+    return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+        __block NSURLSessionDataTask *task = [self POST:URLString
+                                             parameters:parameters
+                                               progress:^(NSProgress *uploadProgress) {
+                                                   [progress sendNext:uploadProgress];
+                                               }
+                                             completion:^(id response, NSError *error) {
+                                                 if (!error) {
+                                                     [progress sendCompleted];
+                                                     [subscriber sendNext:response];
+                                                     [subscriber sendCompleted];
+                                                 } else {
+                                                     [progress sendError:error];
+                                                     [subscriber sendError:error];
+                                                 }
+                                             }];
+
+        return [RACDisposable disposableWithBlock:^{
+            [task cancel];
+        }];
+    }] setNameWithFormat:@"%@ -rac_POST: %@, parameters: %@, progress: %@",
+            self.class, URLString, parameters, progress];
+}
+
+- (RACSignal *)rac_POST:(NSString *)URLString
+             parameters:(NSDictionary *)parameters
+constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
+               progress:(id<RACSubscriber>)progress {
+    return [[RACSignal createSignal:^RACDisposable *(id<RACSubscriber> subscriber) {
+        __block NSURLSessionDataTask *task = [self POST:URLString
+                                             parameters:parameters
+                              constructingBodyWithBlock:block
+                                               progress:^(NSProgress *uploadProgress) {
+                                                   [progress sendNext:uploadProgress];
+                                               }
+                                             completion:^(id response, NSError *error) {
+                                                 if (!error) {
+                                                     [progress sendCompleted];
+                                                     [subscriber sendNext:response];
+                                                     [subscriber sendCompleted];
+                                                 } else {
+                                                     [progress sendError:error];
+                                                     [subscriber sendError:error];
+                                                 }
+                                             }];
+
+        return [RACDisposable disposableWithBlock:^{
+            [task cancel];
+        }];
+    }] setNameWithFormat:@"%@ -rac_POST: %@, parameters: %@, constructingBodyWithBlock %@, progress %@",
+            self.class, URLString, parameters, block, progress];
 }
 
 @end

--- a/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.m
+++ b/sources/ReactiveCocoa/OVCHTTPSessionManager+ReactiveCocoa.m
@@ -180,12 +180,12 @@ constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block {
                                               }
                                             completion:^(id response, NSError *error) {
                                                 if (!error) {
-                                                    [progress sendCompleted];
                                                     [subscriber sendNext:response];
                                                     [subscriber sendCompleted];
+                                                    [progress sendCompleted];
                                                 } else {
-                                                    [progress sendError:error];
                                                     [subscriber sendError:error];
+                                                    [progress sendError:error];
                                                 }
                                             }];
 
@@ -208,12 +208,12 @@ constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block {
                                                }
                                              completion:^(id response, NSError *error) {
                                                  if (!error) {
-                                                     [progress sendCompleted];
                                                      [subscriber sendNext:response];
                                                      [subscriber sendCompleted];
+                                                     [progress sendCompleted];
                                                  } else {
-                                                     [progress sendError:error];
                                                      [subscriber sendError:error];
+                                                     [progress sendError:error];
                                                  }
                                              }];
 
@@ -237,12 +237,12 @@ constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block
                                                }
                                              completion:^(id response, NSError *error) {
                                                  if (!error) {
-                                                     [progress sendCompleted];
                                                      [subscriber sendNext:response];
                                                      [subscriber sendCompleted];
+                                                     [progress sendCompleted];
                                                  } else {
-                                                     [progress sendError:error];
                                                      [subscriber sendError:error];
+                                                     [progress sendError:error];
                                                  }
                                              }];
 

--- a/tests/OVCHTTPSessionManagerCoreDataTests.m
+++ b/tests/OVCHTTPSessionManagerCoreDataTests.m
@@ -91,11 +91,14 @@
     OVCResponse OVCGenerics(NSArray<OVCManagedTestModel *> *) * __block response = nil;
     NSError * __block error = nil;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client GET:@"models" parameters:nil completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
+#pragma clang diagnostic pop
 
     [self waitForExpectationsWithTimeout:1 handler:nil];
 

--- a/tests/OVCHTTPSessionManagerReactiveTests.m
+++ b/tests/OVCHTTPSessionManagerReactiveTests.m
@@ -79,12 +79,15 @@
     
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[self.client rac_GET:@"model/42" parameters:nil] subscribeNext:^(OVCResponse *r) {
         response = r;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertTrue([response.result isKindOfClass:[OVCTestModel class]], @"should return a test model");
@@ -105,12 +108,15 @@
     
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[self.client rac_GET:@"model/42" parameters:nil] subscribeError:^(NSError *e) {
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     OVCResponse *response = error.ovc_response;
@@ -161,12 +167,15 @@
     
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[self.client rac_POST:@"models" parameters:@{@"name": @"Iron Man"}] subscribeNext:^(OVCResponse *r) {
         response = r;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertTrue([response.result isKindOfClass:[OVCTestModel class]], @"should return a test model");
@@ -187,12 +196,15 @@
     
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[self.client rac_POST:@"models" parameters:@{@"name": @"Iron Man"}] subscribeError:^(NSError *e) {
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     OVCResponse *response = error.ovc_response;

--- a/tests/OVCHTTPSessionManagerTests.m
+++ b/tests/OVCHTTPSessionManagerTests.m
@@ -83,13 +83,16 @@
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client GET:@"model/42" parameters:nil completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNil(error, @"should not return an error");
@@ -113,13 +116,16 @@
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client GET:@"model/42" parameters:nil completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(error, @"should return an error");
@@ -173,11 +179,14 @@
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client POST:@"models" parameters:@{@"name": @"Iron Man"} completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
+#pragma clang diagnostic pop
 
     [self waitForExpectationsWithTimeout:1 handler:nil];
 
@@ -203,13 +212,16 @@
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client POST:@"models" parameters:@{@"name": @"Iron Man"} completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNil(error, @"should not return an error");
@@ -231,13 +243,16 @@
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client POST:@"models" parameters:@{@"name": @"Iron Man"} completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNotNil(error, @"should return an error");

--- a/tests/OVCResponseClassPerPathTest.m
+++ b/tests/OVCResponseClassPerPathTest.m
@@ -90,13 +90,16 @@
     XCTestExpectation *completed = [self expectationWithDescription:@"completed"];
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client GET:@"model/42" parameters:nil completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNil(error, @"should not return an error");
@@ -122,12 +125,15 @@
     OVCResponse * __block response = nil;
     NSError * __block error = nil;
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.client GET:@"model_with_custom_envelop/42" parameters:nil completion:^(OVCResponse *r, NSError *e) {
         response = r;
         error = e;
         [completed fulfill];
     }];
-    
+#pragma clang diagnostic pop
+
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
     XCTAssertNil(error, @"should not return an error");


### PR DESCRIPTION
Add new `progress` attribute from `AFNetworking`, because progressless methods marked as deprecated. Also, `ReactiveCocoa` version now send `NSProgress` object to `Next` on each data update.
***
Please, merge it to master, thank you!